### PR TITLE
Fix broken/stale CMake scripts

### DIFF
--- a/build_python_wheel.sh
+++ b/build_python_wheel.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_ROOT="${PANTHERA_BUILD_ROOT:-${ROOT_DIR}/build/python_wheel}"
+STAGE_DIR="${BUILD_ROOT}/stage"
+MOTOR_BUILD_DIR="${BUILD_ROOT}/motor_cpp"
+PY_SRC_DIR="${BUILD_ROOT}/python_src"
+WHEEL_DIR="${PANTHERA_WHEEL_DIR:-${ROOT_DIR}/dist}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+
+if [[ "${1:-}" == "--clean" ]]; then
+    rm -rf "${BUILD_ROOT}" "${WHEEL_DIR}"
+fi
+
+command -v cmake >/dev/null 2>&1 || {
+    echo "cmake is required but was not found on PATH." >&2
+    exit 1
+}
+
+command -v pkg-config >/dev/null 2>&1 || {
+    echo "pkg-config is required to build bundled LCM but was not found on PATH." >&2
+    echo "On Ubuntu, install system build dependencies with:" >&2
+    echo "  sudo apt-get install -y pkg-config libglib2.0-dev libserialport-dev libyaml-cpp-dev" >&2
+    exit 1
+}
+
+pkg-config --exists glib-2.0 || {
+    echo "glib-2.0 development files are required to build bundled LCM." >&2
+    echo "On Ubuntu, install system build dependencies with:" >&2
+    echo "  sudo apt-get install -y pkg-config libglib2.0-dev libserialport-dev libyaml-cpp-dev" >&2
+    exit 1
+}
+
+command -v "${PYTHON_BIN}" >/dev/null 2>&1 || {
+    echo "${PYTHON_BIN} is required but was not found on PATH." >&2
+    exit 1
+}
+
+"${PYTHON_BIN}" -m pip --version >/dev/null 2>&1 || {
+    echo "${PYTHON_BIN} -m pip is required." >&2
+    exit 1
+}
+
+"${PYTHON_BIN}" -c "import pybind11" >/dev/null 2>&1 || {
+    echo "pybind11 is required in the selected Python environment." >&2
+    echo "Install it with: ${PYTHON_BIN} -m pip install pybind11" >&2
+    exit 1
+}
+
+"${PYTHON_BIN}" -c "import wheel" >/dev/null 2>&1 || {
+    echo "wheel is required in the selected Python environment." >&2
+    echo "Install it with: ${PYTHON_BIN} -m pip install wheel" >&2
+    exit 1
+}
+
+mkdir -p "${BUILD_ROOT}" "${STAGE_DIR}" "${WHEEL_DIR}"
+
+echo "==> Building and installing motor C++ SDK into ${STAGE_DIR}"
+cmake \
+    -S "${ROOT_DIR}/panthera_cpp/motor_cpp" \
+    -B "${MOTOR_BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_INSTALL_PREFIX="${STAGE_DIR}"
+
+cmake --build "${MOTOR_BUILD_DIR}" --target install --parallel "${JOBS}"
+
+echo "==> Preparing staged Python source tree at ${PY_SRC_DIR}"
+rm -rf "${PY_SRC_DIR}"
+mkdir -p "${PY_SRC_DIR}"
+
+cp "${ROOT_DIR}/panthera_python/CMakeLists.txt" "${PY_SRC_DIR}/"
+cp "${ROOT_DIR}/panthera_python/setup.py" "${PY_SRC_DIR}/"
+cp "${ROOT_DIR}/panthera_python/pyproject.toml" "${PY_SRC_DIR}/"
+cp "${ROOT_DIR}/panthera_python/README.md" "${PY_SRC_DIR}/"
+cp "${ROOT_DIR}/panthera_python/requirements.txt" "${PY_SRC_DIR}/"
+cp -R "${ROOT_DIR}/panthera_python/src" "${PY_SRC_DIR}/src"
+cp -R "${ROOT_DIR}/panthera_python/hightorque_robot" "${PY_SRC_DIR}/hightorque_robot"
+cp -R "${ROOT_DIR}/panthera_python/scripts" "${PY_SRC_DIR}/scripts"
+cp -R "${ROOT_DIR}/panthera_python/robot_param" "${PY_SRC_DIR}/robot_param"
+cp -R "${ROOT_DIR}/panthera_python/Panthera-HT_description" "${PY_SRC_DIR}/Panthera-HT_description"
+cp -R "${ROOT_DIR}/panthera_python/images" "${PY_SRC_DIR}/images"
+
+echo "==> Copying staged SDK shared libraries into the Python package"
+find "${STAGE_DIR}/lib" -maxdepth 1 \( -type f -o -type l \) \( -name "*.so" -o -name "*.so.*" \) \
+    -exec cp -L {} "${PY_SRC_DIR}/hightorque_robot/" \;
+
+echo "==> Building Python wheel into ${WHEEL_DIR}"
+(
+    cd "${PY_SRC_DIR}"
+    CMAKE_PREFIX_PATH="${STAGE_DIR}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}" \
+        "${PYTHON_BIN}" -m pip wheel . --no-deps --no-build-isolation -w "${WHEEL_DIR}"
+)
+
+echo "==> Wheel build complete"
+ls -1 "${WHEEL_DIR}"/hightorque_robot-*.whl

--- a/panthera_cpp/motor_cpp/CMakeLists.txt
+++ b/panthera_cpp/motor_cpp/CMakeLists.txt
@@ -41,6 +41,7 @@ set(motor_SRCS
 )
 
 add_library(hightorque_motor SHARED ${motor_SRCS})
+add_library(hightorque_motor::hightorque_motor ALIAS hightorque_motor)
 
 target_include_directories(hightorque_motor PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -68,6 +69,8 @@ target_link_libraries(hightorque_motor
 set_target_properties(hightorque_motor PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${VERSION_MAJOR}
+    BUILD_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN"
     PUBLIC_HEADER "include/hardware/robot.hpp;include/hardware/motor.hpp;include/hardware/canport.hpp;include/hardware/canboard.hpp;include/parse_robot_params.hpp;include/serial_struct.hpp;include/serial_driver.hpp;include/crc/crc8.hpp;include/crc/crc16.hpp;msg/motor_msg/motor_msg.hpp"
 )
 
@@ -97,7 +100,7 @@ install(EXPORT hightorque_motorTargets
 # CMake 配置文件
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hightorque_robotConfig.cmake.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hightorque_motorConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/hightorque_motorConfig.cmake
     INSTALL_DESTINATION lib/cmake/hightorque_motor
 )

--- a/panthera_cpp/motor_cpp/cmake/hightorque_motorConfig.cmake.in
+++ b/panthera_cpp/motor_cpp/cmake/hightorque_motorConfig.cmake.in
@@ -1,0 +1,30 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(lcm REQUIRED)
+find_dependency(serial_cmake REQUIRED)
+find_dependency(yaml-cpp REQUIRED)
+
+find_library(SERIALPORT_LIBRARY serialport)
+if(NOT SERIALPORT_LIBRARY)
+    set(hightorque_motor_FOUND FALSE)
+    if(NOT hightorque_motor_FIND_QUIETLY)
+        message(FATAL_ERROR "libserialport not found. Please install libserialport-dev.")
+    endif()
+    return()
+endif()
+
+if(TARGET serial::serial_cmake AND NOT TARGET serial_cmake)
+    add_library(serial_cmake INTERFACE IMPORTED)
+    target_link_libraries(serial_cmake INTERFACE serial::serial_cmake)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/hightorque_motorTargets.cmake")
+
+get_filename_component(HIGHTORQUE_MOTOR_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+get_filename_component(HIGHTORQUE_MOTOR_CMAKE_DIR "${HIGHTORQUE_MOTOR_CMAKE_DIR}" DIRECTORY)
+get_filename_component(HIGHTORQUE_MOTOR_CMAKE_DIR "${HIGHTORQUE_MOTOR_CMAKE_DIR}" DIRECTORY)
+set(HIGHTORQUE_MOTOR_CONFIG_DIR "${HIGHTORQUE_MOTOR_CMAKE_DIR}/share/hightorque_motor/robot_param")
+
+check_required_components(hightorque_motor)

--- a/panthera_cpp/motor_cpp/cmake/hightorque_robotConfig.cmake.in
+++ b/panthera_cpp/motor_cpp/cmake/hightorque_robotConfig.cmake.in
@@ -8,6 +8,9 @@ find_dependency(lcm REQUIRED)
 find_dependency(serial_cmake REQUIRED)  
 find_dependency(yaml-cpp REQUIRED)
 
+# Backward-compatible config for older consumers that still call
+# find_package(hightorque_robot). New code should use hightorque_motor.
+
 # 查找libserialport库
 find_library(SERIALPORT_LIBRARY serialport)
 if(NOT SERIALPORT_LIBRARY)
@@ -18,13 +21,18 @@ if(NOT SERIALPORT_LIBRARY)
     return()
 endif()
 
+if(TARGET serial::serial_cmake AND NOT TARGET serial_cmake)
+    add_library(serial_cmake INTERFACE IMPORTED)
+    target_link_libraries(serial_cmake INTERFACE serial::serial_cmake)
+endif()
+
 # 包含导出的目标
-include("${CMAKE_CURRENT_LIST_DIR}/hightorque_robotTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/hightorque_motorTargets.cmake")
 
 # 设置配置文件路径变量（供用户使用）
 get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
 get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}" DIRECTORY)
 get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}" DIRECTORY)
-set(HIGHTORQUE_ROBOT_CONFIG_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}/share/hightorque_robot/robot_param")
+set(HIGHTORQUE_ROBOT_CONFIG_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}/share/hightorque_motor/robot_param")
 
 check_required_components(hightorque_robot)

--- a/panthera_cpp/robot_cpp/CMakeLists.txt
+++ b/panthera_cpp/robot_cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(panthera_robot PUBLIC
 # 链接库
 target_link_libraries(panthera_robot
     PUBLIC
-        hightorque_motor
+        hightorque_motor::hightorque_motor
         yaml-cpp
         pinocchio::pinocchio
 )
@@ -82,6 +82,12 @@ install(EXPORT panthera_robotTargets
 # CMake 配置文件
 include(CMakePackageConfigHelpers)
 
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/panthera_robotConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/panthera_robotConfig.cmake
+    INSTALL_DESTINATION lib/cmake/panthera_robot
+)
+
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/panthera_robotConfigVersion.cmake
     VERSION 1.0.0
@@ -89,6 +95,7 @@ write_basic_package_version_file(
 )
 
 install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/panthera_robotConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/panthera_robotConfigVersion.cmake
     DESTINATION lib/cmake/panthera_robot
 )
@@ -96,7 +103,7 @@ install(FILES
 # 安装配置文件和URDF
 install(DIRECTORY robot_param/ DESTINATION share/panthera_robot/robot_param
     FILES_MATCHING PATTERN "*.yaml")
-install(DIRECTORY urdf/ DESTINATION share/panthera_robot/urdf
+install(DIRECTORY Panthera-HT_description/urdf/ DESTINATION share/panthera_robot/urdf
     FILES_MATCHING PATTERN "*.urdf")
 
 # ==================== 机械臂控制示例程序 ====================

--- a/panthera_cpp/robot_cpp/cmake/panthera_robotConfig.cmake.in
+++ b/panthera_cpp/robot_cpp/cmake/panthera_robotConfig.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(hightorque_motor REQUIRED)
+find_dependency(yaml-cpp REQUIRED)
+find_dependency(pinocchio REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/panthera_robotTargets.cmake")
+
+get_filename_component(PANTHERA_ROBOT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+get_filename_component(PANTHERA_ROBOT_CMAKE_DIR "${PANTHERA_ROBOT_CMAKE_DIR}" DIRECTORY)
+get_filename_component(PANTHERA_ROBOT_CMAKE_DIR "${PANTHERA_ROBOT_CMAKE_DIR}" DIRECTORY)
+set(PANTHERA_ROBOT_CONFIG_DIR "${PANTHERA_ROBOT_CMAKE_DIR}/share/panthera_robot/robot_param")
+set(PANTHERA_ROBOT_URDF_DIR "${PANTHERA_ROBOT_CMAKE_DIR}/share/panthera_robot/urdf")
+
+check_required_components(panthera_robot)

--- a/panthera_python/CMakeLists.txt
+++ b/panthera_python/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # 查找Python
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-find_package(hightorque_robot REQUIRED)
+find_package(hightorque_motor REQUIRED)
 
 # 查找pybind11 - 优先使用 Python 环境中的版本
 execute_process(
@@ -25,36 +25,27 @@ endif()
 
 find_package(pybind11 CONFIG REQUIRED)
 
-# 添加C++项目的头文件路径
-include_directories(
-    ${HIGHTORQUE_ROBOT_DIR}/include
-    ${HIGHTORQUE_ROBOT_DIR}/include/hardware
-    ${HIGHTORQUE_ROBOT_DIR}/include/crc
-    ${HIGHTORQUE_ROBOT_DIR}/msg/motor_msg
-)
-
-# 查找依赖库
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LCM REQUIRED lcm)
-pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
-
 # 创建pybind11模块
 pybind11_add_module(_hightorque_robot src/bindings.cpp)
 
 # 链接库
 target_link_libraries(_hightorque_robot PRIVATE
-    ${HIGHTORQUE_ROBOT_LIB}
-    ${LCM_LIBRARIES}
-    ${YAML_CPP_LIBRARIES}
-    pthread
-    rt
-    hightorque_robot
+    hightorque_motor::hightorque_motor
 )
 
-# 设置输出目录
-set_target_properties(_hightorque_robot PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hightorque_robot
-)
+if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set_target_properties(_hightorque_robot PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+        BUILD_RPATH "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
+    )
+else()
+    set_target_properties(_hightorque_robot PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hightorque_robot
+        BUILD_RPATH "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
+    )
+endif()
 
 # 安装规则
 install(TARGETS _hightorque_robot

--- a/panthera_python/hightorque_robot/__init__.py
+++ b/panthera_python/hightorque_robot/__init__.py
@@ -1,0 +1,3 @@
+"""Python bindings for the HighTorque motor SDK."""
+
+from ._hightorque_robot import *  # noqa: F401,F403

--- a/panthera_python/setup.py
+++ b/panthera_python/setup.py
@@ -25,7 +25,7 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}',
-            f'-DPYTHON_EXECUTABLE={sys.executable}',
+            f'-DPython3_EXECUTABLE={sys.executable}',
         ]
 
         cfg = 'Debug' if self.debug else 'Release'
@@ -51,6 +51,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),
+    package_data={"hightorque_robot": ["*.so", "*.so.*"]},
+    include_package_data=True,
     ext_modules=[CMakeExtension('hightorque_robot._hightorque_robot')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,


### PR DESCRIPTION
The current CMake scripts are stale and do not match up with what the python package expects when it is being built. I've fixed that and added a script that builds the python wheel in one step.