### PR TITLE
fix SDK build and Python packaging for ubuntu 20.04

### DIFF
--- a/panthera_cpp/README.md
+++ b/panthera_cpp/README.md
@@ -9,6 +9,18 @@ Panthera C++ SDK 分为两个层级：
 - **motor_cpp**: 电机底层驱动 SDK - 提供单个电机的基础控制功能
 - **robot_cpp**: 机械臂高级控制 SDK - 基于 motor_cpp 构建的机械臂级别控制库
 
+### 名称对照
+
+| 层级 | 目录 | CMake 包/库 | 代码命名空间 | 用途 |
+|------|------|-------------|--------------|------|
+| 电机底层 | `motor_cpp` | `hightorque_motor` | `hightorque_robot` | 串口、CAN、电机和底层 robot 类 |
+| C++ 机械臂高层 | `robot_cpp` | `panthera_robot` | `panthera` | 运动学、动力学和轨迹控制 |
+
+`hightorque_robot` 是底层 C++ 命名空间，也是 Python 导入包名，但不是
+motor SDK 的 CMake 包名。外部 CMake 项目应使用
+`find_package(hightorque_motor CONFIG REQUIRED)` 和
+`hightorque_motor::hightorque_motor`。
+
 ### SDK 架构关系
 
 ```
@@ -82,25 +94,36 @@ sudo apt install pinocchio
 
 ### 编译
 
-#### 编译 motor_cpp（电机底层 SDK）
+#### 仅编译 motor_cpp（电机底层 SDK 或 Python 绑定需要）
 
 ```bash
 cd motor_cpp
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
+cmake -S . -B build
+cmake --build build -j$(nproc)
+sudo cmake --install build
+sudo ldconfig
 ```
 
 #### 编译 robot_cpp（机械臂高级 SDK）
 
 ```bash
-cd robot_cpp
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
+cd ../robot_cpp
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
-> **注意**: robot_cpp 会自动链接 motor_cpp，无需单独编译 motor_cpp。
+> `robot_cpp` 当前通过 `add_subdirectory(../motor_cpp)` 直接编译同仓库中的
+> motor SDK，因此只构建 C++ 高层库时无需提前安装 `motor_cpp`。Python
+> 绑定使用已安装的 `hightorque_motor` CMake 包，必须先执行上面的
+> `motor_cpp` 安装步骤。
+
+### 当前构建边界
+
+- `motor_cpp` 已导出完整的 `hightorque_motor` CMake 包，可供 Python
+  绑定和外部 CMake 项目使用。
+- `robot_cpp` 当前仍与同仓库的 `motor_cpp` 源码绑定。
+- `robot_cpp` 尚未生成完整的 `panthera_robotConfig.cmake`，安装后暂不应
+  依赖 `find_package(panthera_robot)`；这是后续需要完善的打包项。
 
 ## 项目结构
 

--- a/panthera_cpp/motor_cpp/CMakeLists.txt
+++ b/panthera_cpp/motor_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(hightorque_motor)
 
 if(NOT CMAKE_INSTALL_PREFIX)
@@ -97,7 +97,7 @@ install(EXPORT hightorque_motorTargets
 # CMake 配置文件
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hightorque_robotConfig.cmake.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hightorque_motorConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/hightorque_motorConfig.cmake
     INSTALL_DESTINATION lib/cmake/hightorque_motor
 )

--- a/panthera_cpp/motor_cpp/README.md
+++ b/panthera_cpp/motor_cpp/README.md
@@ -81,6 +81,8 @@ motor_cpp/
 ### 库和命名空间
 
 - **库名称**: `hightorque_motor`
+- **CMake 包名称**: `hightorque_motor`
+- **导出目标**: `hightorque_motor::hightorque_motor`
 - **命名空间**: `hightorque_robot`
 - **主要类**:
   - `hightorque_robot::motor` - 单个电机控制类
@@ -100,7 +102,7 @@ chmod 777 Interface_cpp_setup.sh
 
 ### 依赖库
 
-* CMake >= 3.0.2
+* CMake >= 3.5
 * C++11 编译器
 * libserialport（串口通信）
 * yaml-cpp（YAML配置文件解析）
@@ -120,23 +122,36 @@ sudo apt-get install libyaml-cpp-dev
 ## 三、编译
 
 1. 获取代码
-```
-git clone http://git.clicki.cn/livelybot/hightorque_robot.git
+```bash
+git clone https://github.com/HighTorque-Robotics/Panthera-HT_SDK.git
 ```
 
 2. 编译
-```
-cd hightorque_robot
-mkdir build
-cd build
-cmake ..
-make -j8
+```bash
+cd Panthera-HT_SDK/panthera_cpp/motor_cpp
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
 3. 安装
+```bash
+sudo cmake --install build
+sudo ldconfig
 ```
-sudo make install
+
+> `motor_cpp` 要求 CMake 3.5 或更高版本。请使用独立的 `build` 目录，
+> 不要在源码目录中运行 `cmake .`。
+
+安装后，外部 CMake 项目应按以下方式链接：
+
+```cmake
+find_package(hightorque_motor CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE
+    hightorque_motor::hightorque_motor
+)
 ```
+
+注意：`hightorque_robot` 是源码中的 C++ 命名空间，不是 CMake 包名称。
 
 4. 补充
 当外部项目调用当前库的时候，可能会出现找不到liblivelybot_serial.so.*的情况，这个时候需要申明安装位置

--- a/panthera_cpp/motor_cpp/cmake/hightorque_motorConfig.cmake.in
+++ b/panthera_cpp/motor_cpp/cmake/hightorque_motorConfig.cmake.in
@@ -11,20 +11,17 @@ find_dependency(yaml-cpp REQUIRED)
 # 查找libserialport库
 find_library(SERIALPORT_LIBRARY serialport)
 if(NOT SERIALPORT_LIBRARY)
-    set(hightorque_robot_FOUND FALSE)
-    if(NOT hightorque_robot_FIND_QUIETLY)
+    set(hightorque_motor_FOUND FALSE)
+    if(NOT hightorque_motor_FIND_QUIETLY)
         message(FATAL_ERROR "libserialport not found. Please install with: sudo apt-get install libserialport-dev")
     endif()
     return()
 endif()
 
 # 包含导出的目标
-include("${CMAKE_CURRENT_LIST_DIR}/hightorque_robotTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/hightorque_motorTargets.cmake")
 
 # 设置配置文件路径变量（供用户使用）
-get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
-get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}" DIRECTORY)
-get_filename_component(HIGHTORQUE_ROBOT_CMAKE_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}" DIRECTORY)
-set(HIGHTORQUE_ROBOT_CONFIG_DIR "${HIGHTORQUE_ROBOT_CMAKE_DIR}/share/hightorque_robot/robot_param")
+set(HIGHTORQUE_MOTOR_CONFIG_DIR "${PACKAGE_PREFIX_DIR}/share/hightorque_motor/robot_param")
 
-check_required_components(hightorque_robot)
+check_required_components(hightorque_motor)

--- a/panthera_cpp/motor_cpp/doc/CLAUDE.md
+++ b/panthera_cpp/motor_cpp/doc/CLAUDE.md
@@ -7,13 +7,12 @@
 ### 构建命令
 ```bash
 # 标准构建流程
-mkdir build && cd build
-cmake ..
-make -j8
+cmake -S . -B build
+cmake --build build -j$(nproc)
 
 # 安装到自定义路径（默认：build/install）
-cmake -DCMAKE_INSTALL_PREFIX=/custom/path ..
-make install
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/custom/path
+cmake --install build
 ```
 
 ### 依赖项

--- a/panthera_cpp/motor_cpp/doc/使用指南.md
+++ b/panthera_cpp/motor_cpp/doc/使用指南.md
@@ -1,21 +1,20 @@
-# hightorque_robot 库使用指南
+# hightorque_motor 库使用指南
 
 ## 安装库
 
 ### 1. 编译并安装库
 ```bash
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j8
-sudo make install
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --build build -j$(nproc)
+sudo cmake --install build
+sudo ldconfig
 ```
 
 ### 2. 或者安装到自定义位置
 ```bash
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ..
-make -j8
-make install
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/local
+cmake --build build -j$(nproc)
+cmake --install build
 ```
 
 ## 在其他CMake项目中使用
@@ -23,17 +22,19 @@ make install
 ### CMakeLists.txt 配置
 
 ```cmake
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(my_robot_project)
 
-# 查找hightorque_robot库
-find_package(hightorque_robot REQUIRED)
+# 查找 hightorque_motor CMake 包
+find_package(hightorque_motor CONFIG REQUIRED)
 
 # 创建可执行文件
 add_executable(my_robot_app main.cpp)
 
 # 链接库（会自动链接所有依赖项）
-target_link_libraries(my_robot_app hightorque_robot::hightorque_robot)
+target_link_libraries(my_robot_app PRIVATE
+    hightorque_motor::hightorque_motor
+)
 ```
 
 ### 如果安装到自定义位置
@@ -42,8 +43,10 @@ target_link_libraries(my_robot_app hightorque_robot::hightorque_robot)
 export CMAKE_PREFIX_PATH=$HOME/local:$CMAKE_PREFIX_PATH
 
 # 或者在cmake时指定
-cmake -DCMAKE_PREFIX_PATH=$HOME/local ..
+cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/local
 ```
+
+`hightorque_robot` 是 C++ 命名空间，不是 CMake 包名称。
 
 ## C++ 代码示例
 

--- a/panthera_cpp/motor_cpp/src/hardware/robot.cpp
+++ b/panthera_cpp/motor_cpp/src/hardware/robot.cpp
@@ -21,15 +21,39 @@ namespace hightorque_robot
     void robot::init_robot(const std::string& config_path)
     {
         auto config = YAML::LoadFile(config_path);
-        std::cout << "robot_config: " << config["robot"]["robot_name"].as<std::string>() << std::endl;
-        auto param_file = config_path;
-        if (config["robot"]["param_file"])
+        const auto robot_config = config["robot"];
+        if (!robot_config || !robot_config.IsMap())
         {
-            param_file = config["robot"]["param_file"].as<std::string>();
+            throw std::runtime_error(
+                "Invalid robot config '" + config_path +
+                "': missing 'robot' mapping");
         }
-        
+
+        std::string config_name;
+        if (robot_config["robot_name"])
+        {
+            config_name = robot_config["robot_name"].as<std::string>();
+        }
+        else if (robot_config["name"])
+        {
+            config_name = robot_config["name"].as<std::string>();
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Invalid robot config '" + config_path +
+                "': missing 'robot.robot_name' or 'robot.name'");
+        }
+        std::cout << "robot_config: " << config_name << std::endl;
+
+        auto param_file = config_path;
+        if (robot_config["param_file"])
+        {
+            param_file = robot_config["param_file"].as<std::string>();
+        }
+
         // 如果param_file是相对路径，则相对于config_path的目录
-        if (param_file[0] != '/') {
+        if (!param_file.empty() && param_file[0] != '/') {
             size_t last_slash = config_path.find_last_of('/');
             if (last_slash != std::string::npos) {
                 std::string config_dir = config_path.substr(0, last_slash + 1);
@@ -411,6 +435,16 @@ namespace hightorque_robot
                 int serial_id = port_params.second.serial_id;
 
                 serial_id_old.push_back(serial_id);
+                if (serial_id <= 0 ||
+                    static_cast<size_t>(serial_id) > str.size())
+                {
+                    throw std::runtime_error(
+                        "Serial device configuration requires serial_id " +
+                        std::to_string(serial_id) + ", but only " +
+                        std::to_string(str.size()) +
+                        " matching port(s) were found for prefix '" +
+                        Serial_Type + "'. Check USB connection and device permissions.");
+                }
 
                 serial_driver *s = new serial_driver(&str[serial_id - 1], Seial_baudrate, canport_error_output_flag);
                 ser.push_back(s);

--- a/panthera_cpp/robot_cpp/README.md
+++ b/panthera_cpp/robot_cpp/README.md
@@ -30,6 +30,10 @@
 
 ## 环境安装
 
+`robot_cpp` 生成高层库 `panthera_robot`。它通过
+`add_subdirectory(../motor_cpp)` 使用同仓库中的底层 `hightorque_motor`
+源码，因此单独构建本目录时不需要先安装 motor SDK。
+
 ### 系统要求
 - Ubuntu 20.04 / 22.04 / 24.04
 - CMake >= 3.10
@@ -59,13 +63,15 @@ sudo apt install pinocchio
 
 ```bash
 cd ~/Panthera-HT_git/Panthera-HT_SDK/panthera_cpp/robot_cpp
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
-sudo make install
+cmake -S . -B build
+cmake --build build -j$(nproc)
+sudo cmake --install build
+sudo ldconfig
 ```
 
-编译成功后，库文件会安装到系统路径，可以在任何位置使用。
+编译成功后，库文件会安装到系统路径。当前安装规则尚未生成完整的
+`panthera_robotConfig.cmake`，外部 CMake 项目暂不能直接依赖
+`find_package(panthera_robot)`。
 
 ## 快速开始
 

--- a/panthera_python/CMakeLists.txt
+++ b/panthera_python/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # 查找Python
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-find_package(hightorque_robot REQUIRED)
+find_package(hightorque_motor CONFIG REQUIRED)
 
 # 查找pybind11 - 优先使用 Python 环境中的版本
 execute_process(
@@ -25,35 +25,22 @@ endif()
 
 find_package(pybind11 CONFIG REQUIRED)
 
-# 添加C++项目的头文件路径
-include_directories(
-    ${HIGHTORQUE_ROBOT_DIR}/include
-    ${HIGHTORQUE_ROBOT_DIR}/include/hardware
-    ${HIGHTORQUE_ROBOT_DIR}/include/crc
-    ${HIGHTORQUE_ROBOT_DIR}/msg/motor_msg
-)
-
-# 查找依赖库
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LCM REQUIRED lcm)
-pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
-
 # 创建pybind11模块
 pybind11_add_module(_hightorque_robot src/bindings.cpp)
 
 # 链接库
 target_link_libraries(_hightorque_robot PRIVATE
-    ${HIGHTORQUE_ROBOT_LIB}
-    ${LCM_LIBRARIES}
-    ${YAML_CPP_LIBRARIES}
-    pthread
-    rt
-    hightorque_robot
+    hightorque_motor::hightorque_motor
 )
 
-# 设置输出目录
+# setup.py 构建 wheel 时会传入输出目录；直接运行 CMake 时输出到源码包目录。
+if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/hightorque_robot)
+endif()
+
 set_target_properties(_hightorque_robot PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hightorque_robot
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 # 安装规则

--- a/panthera_python/README.md
+++ b/panthera_python/README.md
@@ -33,6 +33,24 @@
 
 ## 环境安装
 
+### 包与依赖关系
+
+Python SDK 的导入名称是 `hightorque_robot`，但它绑定的是 C++ 底层库
+`hightorque_motor`：
+
+```text
+Panthera_lib（纯 Python 高层机械臂控制）
+    -> hightorque_robot（Python/pybind11 模块）
+        -> hightorque_motor（motor_cpp CMake 包和动态库）
+```
+
+它不链接 C++ 高层库 `panthera_robot`。名称相近但用途不同：
+
+- `hightorque_motor`：CMake 包和 `libhightorque_motor.so`
+- `hightorque_robot`：C++ 命名空间及 Python 导入包
+- `panthera_robot`：`robot_cpp` 生成的 C++ 高层机械臂库
+- `Panthera_lib`：基于 `hightorque_robot` 的纯 Python 高层封装
+
 ### 推荐：使用独立的 conda 环境
 
 为避免与系统环境（如 ROS）冲突，强烈建议创建独立的 conda 环境：
@@ -95,21 +113,41 @@ pip install pybind11
 
 ```bash
 cd ../panthera_cpp/motor_cpp
-mkdir -p build && cd build
-cmake ..
-make
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
-**步骤4：编译 Python 绑定**
+Python 绑定需要使用安装后的 CMake 包，因此必须安装：
+
+```bash
+sudo cmake --install build
+sudo ldconfig
+```
+**步骤4：安装 Python 绑定**
 
 ```bash
 cd ../../panthera_python
-mkdir -p build && cd build
-cmake ..
-make
+python -m pip install .
 ```
 
-编译成功后会显示 `Build target _hightorque_robot`。
+该命令会使用当前 Python 环境构建扩展，并将 `hightorque_robot` 安装到
+当前环境的 `site-packages`。新终端中激活同一个环境后仍可导入。
+
+开发时需要让源码修改立即生效，可以改用：
+
+```bash
+python -m pip install -e .
+```
+
+在任意目录验证底层 Python 扩展：
+
+```bash
+cd /tmp
+python -c "import hightorque_robot; print('电机 SDK 安装成功')"
+```
+
+仅执行 `cmake -S . -B build && cmake --build build` 只是生成扩展文件，
+不会把 Python 包安装进当前环境，因此换到其他目录或新终端后可能无法导入。
 
 ---
 
@@ -135,15 +173,20 @@ pip install "scipy>=1.9.0"
 
 手动验证：
 ```bash
-python -c "import hightorque_robot; print('✓ 电机 SDK 安装成功')"
-python -c "import pinocchio as pin; print('✓ pin 安装成功')"
-python -c "import yaml; print('✓ pyyaml 安装成功')"
+python -c "from hightorque_robot import _hightorque_robot; print('电机 SDK 安装成功')"
+python -c "import pinocchio as pin; print('pin 安装成功')"
+python -c "import yaml; print('pyyaml 安装成功')"
 ```
 
 安装成功后，在 `scripts` 目录下运行例程：
-```python
-# 注意：Panthera_lib 作为源码提供，需要在 scripts 目录下使用
+```bash
 cd scripts
+python -c "from Panthera_lib import Panthera; print('Panthera_lib 导入成功')"
+```
+
+Python 代码中使用：
+
+```python
 from Panthera_lib import Panthera
 ```
 
@@ -474,18 +517,14 @@ git clone https://github.com/jbeder/yaml-cpp.git
 cd yaml-cpp
 git checkout yaml-cpp-0.6.1
 
-创建干净的构建目录
-mkdir build
-cd build
-
 配置编译选项
-cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
 
 编译
-make -j$(nproc)
+cmake --build build -j$(nproc)
 
 安装
-sudo make install
+sudo cmake --install build
 
 更新库缓存
 sudo ldconfig

--- a/panthera_python/README.md
+++ b/panthera_python/README.md
@@ -127,17 +127,12 @@ sudo ldconfig
 
 ```bash
 cd ../../panthera_python
-python -m pip install .
+python -m pip install -e . --no-build-isolation --no-deps -v
 ```
 
 该命令会使用当前 Python 环境构建扩展，并将 `hightorque_robot` 安装到
 当前环境的 `site-packages`。新终端中激活同一个环境后仍可导入。
 
-开发时需要让源码修改立即生效，可以改用：
-
-```bash
-python -m pip install -e .
-```
 
 在任意目录验证底层 Python 扩展：
 

--- a/panthera_python/hightorque_robot/__init__.py
+++ b/panthera_python/hightorque_robot/__init__.py
@@ -1,0 +1,1 @@
+from ._hightorque_robot import *

--- a/panthera_python/robot_param/Follower.yaml
+++ b/panthera_python/robot_param/Follower.yaml
@@ -1,5 +1,5 @@
 robot:
-  name: "Panthera-HT"
+  robot_name: "Panthera-HT"
   param_file: "../robot_param/motor_param/6dof_Panthera_params_follower.yaml"
   joint_limits:
     lower: [-2.4, -0.1, -0.1, -1.6, -1.7, -2.5]

--- a/panthera_python/robot_param/Leader.yaml
+++ b/panthera_python/robot_param/Leader.yaml
@@ -1,5 +1,5 @@
 robot:
-  name: "Panthera-HT"
+  robot_name: "Panthera-HT"
   param_file: "../robot_param/motor_param/6dof_Panthera_params_leader.yaml"
   joint_limits:
     lower: [-2.4, 0.0, 0.0, -1.6, -1.7, -2.5]

--- a/panthera_python/scripts/motor_example/motor_README.md
+++ b/panthera_python/scripts/motor_example/motor_README.md
@@ -39,9 +39,8 @@ pip3 install pybind11 numpy
 需要先编译C++项目:
 ```bash
 cd path/to/hightorque_robot
-mkdir -p build && cd build
-cmake ..
-make
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
 ## 安装
@@ -49,15 +48,14 @@ make
 ### 方式1: 使用pip安装 (开发模式)
 ```bash
 cd path/to/hightorque_robot_python
-pip3 install -e .
+python -m pip install -e .
 ```
 
 ### 方式2: 使用CMake构建
 ```bash
 cd path/to/hightorque_robot_python
-mkdir -p build && cd build
-cmake ..
-make
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
 ## 使用示例
@@ -194,9 +192,9 @@ robot.set_reset()
 ### 找不到C++库
 确保C++项目已编译:
 ```bash
-cd path/to/hightorque_robot/build
-cmake ..
-make
+cd path/to/hightorque_robot
+cmake -S . -B build
+cmake --build build -j$(nproc)
 ```
 
 ### 找不到pybind11

--- a/panthera_python/setup.py
+++ b/panthera_python/setup.py
@@ -25,7 +25,7 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}',
-            f'-DPYTHON_EXECUTABLE={sys.executable}',
+            f'-DPython3_EXECUTABLE={sys.executable}',
         ]
 
         cfg = 'Debug' if self.debug else 'Release'


### PR DESCRIPTION
## 中文

本 PR 修复 Panthera-HT SDK 的构建与安装问题：

- 兼容 CMake 4.x
- 统一 `hightorque_motor` CMake 包名和导出目标
- 修复 Python 绑定链接错误
- 支持将 Python 扩展正确安装到 `site-packages`
- 修复 conda Python 解释器选择
- 兼容 `robot.name` 与 `robot.robot_name`
- 串口设备缺失时返回明确错误，避免段错误
- 更新相关 README 和构建流程

已验证：

- `motor_cpp` 完整编译成功
- Python wheel 构建成功
- Python 包可在任意目录导入

## English

This PR fixes build and installation issues in the Panthera-HT SDK:

- Add CMake 4.x compatibility
- Align the `hightorque_motor` CMake package and exported target names
- Fix Python binding linkage
- Install the Python extension correctly into `site-packages`
- Use the correct Python interpreter in conda environments
- Support both `robot.name` and `robot.robot_name`
- Report missing serial devices clearly instead of crashing
- Update the related README files and build instructions

Validated:

- Full `motor_cpp` build succeeds
- Python wheel builds successfully
- The Python package imports correctly from any directory